### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.0.0
+## 2.0.0-nullsafety.2
+
+- Update dependencies
+
+## 2.0.0-nullsafety.1
 
 - migration to null safety
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simple internationalization (i18n) package for Dart and Flutter.
 Note: Want to use null-safe version? Use:
 
     dependencies:
-      i69n: ^2.0.0-nullsafe.1
+      i69n: ^2.0.0-nullsafety.2
 
 # Overview
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: i69n
 description: Simple internationalization tool for Dart and Flutter, based on YAML files and source code generation.
-version: 2.0.0-nullsafety.1
+version: 2.0.0-nullsafety.2
 homepage: https://github.com/fnx-io/i69n
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  build: ^2.0.0
-  build_config: ^0.4.7
+  build: ^2.0.1
+  build_config: ^1.0.0
   yaml: ^3.1.0
   dart_style: ^2.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0
   test: ^1.16.8
-  build_runner: ^1.12.2
-  build_web_compilers: ^2.16.5
+  build_runner: ^2.0.1
+  build_web_compilers: ^3.0.0


### PR DESCRIPTION
Hi Tomáš,

First of all, thanks for this great package! I am using it literally in every Flutter project I can.

Recently, a new `1.0.0` version of `build_config` was released with the `null safety` support, and a `build_runner` v`2.0.1` is also out there. But because `i69n` depends on `build_config: ^0.4.7`, it makes it impossible to use with the latest `build_runner` and other code generating plugins. 

<img width="825" alt="Screenshot 2021-05-01 at 13 33 31" src="https://user-images.githubusercontent.com/1845144/116780314-965cc800-aa84-11eb-9aa7-1edd5bb91e45.png">

This PR contains updates for `build_config`, as well as `build_runner` and `build` dependencies.