### PR TITLE
Create v3.1.0 with updated sdk and dependencies constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0
+
+- Bump the min sdk to `3.6.0`
+- Update `dart_style` constraint to `^3.0.0`
+- Updated other dependencies
+
 ## 3.0.0-alpha.1
 
 - support for custom types and custom imports

--- a/lib/src/i69n_impl.dart
+++ b/lib/src/i69n_impl.dart
@@ -59,7 +59,9 @@ String generateDartContentFromYaml(ClassMeta meta, String yamlContent) {
     output.writeln('');
   }
   try {
-    var formatter = DartFormatter();
+    var formatter = DartFormatter(
+      languageVersion: DartFormatter.latestShortStyleLanguageVersion,
+    );
     return formatter.format(output.toString());
   } catch (e) {
     print(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: i69n
 description: Simple internationalization tool for Dart and Flutter, based on YAML files and source code generation.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/fnx-io/i69n
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ^3.6.0
 
 dependencies:
-  build: ^2.0.1
-  build_config: ^1.0.0
-  yaml: ^3.1.0
-  dart_style: ^2.0.0
+  build: ^2.4.2
+  build_config: ^1.1.2
+  yaml: ^3.1.3
+  dart_style: ^3.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0
-  test: ^1.16.8
-  build_runner: ^2.0.1
-  build_web_compilers: ^3.0.0
+  test: ^1.25.15
+  build_runner: ^2.4.15
+  build_web_compilers: ^4.1.1


### PR DESCRIPTION
A lot of code-generating packages (`freezed`, `injectable`, `bdd_widget_test`) started depending on `dart_style: ^3.0.1`, but `i69n` prevents the upgrade with:
```
Because freezed >=2.5.8 <3.0.0-0.0.dev depends on dart_style ^3.0.1 and i69n 2.1.0 depends on dart_style ^2.0.0, freezed >=2.5.8 <3.0.0-0.0.dev is incompatible with i69n 2.1.0.
So, because <...> depends on both i69n 2.1.0 and freezed 2.5.8, version solving failed.
Failed to update packages.
```
Would you be open to releasing the suggested update soon-ish?