### PR TITLE
feat: add `// dart format off` directive to generated files

### DIFF
--- a/example/exampleMessages.i69n.dart
+++ b/example/exampleMessages.i69n.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element, unused_field, camel_case_types, annotate_overrides, prefer_single_quotes
 // GENERATED FILE, do not edit!
+// dart format off
 import 'package:i69n/i69n.dart' as i69n;
 
 String get _languageCode => 'en';

--- a/example/exampleMessages_cs.i69n.dart
+++ b/example/exampleMessages_cs.i69n.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element, unused_field, camel_case_types, annotate_overrides, prefer_single_quotes
 // GENERATED FILE, do not edit!
+// dart format off
 import 'package:i69n/i69n.dart' as i69n;
 import 'exampleMessages.i69n.dart';
 

--- a/example/exampleMessages_en_GB.i69n.dart
+++ b/example/exampleMessages_en_GB.i69n.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element, unused_field, camel_case_types, annotate_overrides, prefer_single_quotes
 // GENERATED FILE, do not edit!
+// dart format off
 import 'package:i69n/i69n.dart' as i69n;
 import 'exampleMessages.i69n.dart';
 

--- a/lib/src/i69n_impl.dart
+++ b/lib/src/i69n_impl.dart
@@ -21,6 +21,7 @@ String generateDartContentFromYaml(ClassMeta meta, String yamlContent, BuilderOp
   output.writeln(
       '// ignore_for_file: unused_element, unused_field, camel_case_types, annotate_overrides, prefer_single_quotes');
   output.writeln('// GENERATED FILE, do not edit!');
+  output.writeln('// dart format off');
   output.writeln('import \'package:i69n/i69n.dart\' as i69n;');
   if (meta.defaultFileName != null) {
     output.writeln('import \'${meta.defaultFileName}\';');

--- a/test/testMessages.i69n.dart
+++ b/test/testMessages.i69n.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unused_element, unused_field, camel_case_types, annotate_overrides, prefer_single_quotes
 // GENERATED FILE, do not edit!
+// dart format off
 import 'package:i69n/i69n.dart' as i69n;
 import 'dart:io';
 


### PR DESCRIPTION
## Summary

Since Dart 3.7, `dart format` respects the `// dart format off` directive to skip formatting of generated code. Other code generators (e.g. `freezed`) already emit this directive, which prevents `dart format` from rewriting their output.

Currently, `i69n`-generated `.i69n.dart` files do **not** include this directive. This means running `dart format .` (or CI checks like `dart format --set-exit-if-changed .`) will reformat generated files, causing unnecessary diffs or CI failures.

## Changes

- Added `output.writeln('// dart format off');` in the generator (`lib/src/i69n_impl.dart`), right after the existing `// GENERATED FILE, do not edit!` comment
- Updated all checked-in generated files (examples + test) to include the new directive

## Example

Generated files now start with:

```dart
// ignore_for_file: unused_element, unused_field, camel_case_types, annotate_overrides, prefer_single_quotes
// GENERATED FILE, do not edit!
// dart format off
import 'package:i69n/i69n.dart' as i69n;
```

## Test plan

- [x] All existing tests pass (`dart test`: 48/48 passing)
- [x] Verified generated output includes the directive