### PR TITLE
Ukrainian plurals QuantityCategory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.0
+
+- added ukrainian plural language rules
+
 ## 3.5.0
 
 - added "dart format off" to skip formatting and unnecessary VCS changes

--- a/lib/i69n.dart
+++ b/lib/i69n.dart
@@ -1,5 +1,6 @@
 import 'src/cs.dart' as cs;
 import 'src/en.dart' as en;
+import 'src/uk.dart' as uk;
 
 ///
 /// Language specific function, which is provided with a number and should return one of possible categories.
@@ -49,6 +50,7 @@ String ordinal(int count, String languageCode,
 Map<String, CategoryResolver> _resolverRegistry = {
   'en': en.quantityResolver,
   'cs': cs.quantityResolver,
+  'uk': uk.quantityResolver,
 };
 
 String _resolvePlural(int count, String languageCode, QuantityType type,

--- a/lib/src/uk.dart
+++ b/lib/src/uk.dart
@@ -1,0 +1,37 @@
+import 'package:i69n/i69n.dart';
+
+///
+/// Quantity category resolver for ukrainian.
+///
+/// See:
+///
+/// https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#uk
+///
+///
+QuantityCategory quantityResolver(int count, QuantityType type) {
+  if (type == QuantityType.ordinal) return _resolveOrdinal(count);
+  return _resolveCardinal(count);
+}
+
+QuantityCategory _resolveCardinal(int count) {
+  final mod10 = count % 10;
+  final mod100 = count % 100;
+
+  final fewIncludeSet = {2, 3, 4};
+  final fewExcludeSet = {12, 13, 14};
+  final manyIncludeSet = {5, 6, 7, 8, 9};
+  final manyIncludeSet2 = {11, 12, 13, 14};
+
+  if (mod10 == 1 && mod100 != 11) return QuantityCategory.one;
+  if (fewIncludeSet.contains(mod10) && !fewExcludeSet.contains(mod100)) return QuantityCategory.few;
+  if (mod10 == 0 || manyIncludeSet.contains(count) || manyIncludeSet2.contains(mod100)) return QuantityCategory.many;
+
+  return QuantityCategory.other;
+}
+
+QuantityCategory _resolveOrdinal(int count) {
+  var mod10 = count % 10;
+  var mod100 = count % 100;
+  if (mod10 == 3 && mod100 != 13) return QuantityCategory.few;
+  return QuantityCategory.other;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: i69n
 description: Simple internationalization tool for Dart and Flutter, based on YAML files and source code generation.
-version: 3.5.0
+version: 3.6.0
 homepage: https://github.com/fnx-io/i69n
 
 environment:

--- a/test/i69n_test.dart
+++ b/test/i69n_test.dart
@@ -83,6 +83,16 @@ void main() {
       expect(plural(3, 'cs', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('FEW!'));
       expect(plural(10, 'cs', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('OTHER!'));
     });
+
+    test('uk', () {
+      expect(plural(1, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('ONE!'));
+      expect(plural(2, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('FEW!'));
+      expect(plural(5, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('OTHER!'));
+      expect(plural(20, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('OTHER!'));
+      expect(plural(21, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('ONE!'));
+      expect(plural(22, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('FEW!'));
+      expect(plural(25, 'uk', one: 'ONE!', few: 'FEW!', other: 'OTHER!'), equals('OTHER!'));
+    });
   });
 
   group('Message building', () {


### PR DESCRIPTION
I faced a situation when defaultResolver doesn't work properly for Ukrainian language. Surely, I've used i69n.registerResolver() in my project, but decided to create a PR and expand your original project.

During preparation of this PR I chose not to add 
```
print('Asynchronous load of Ukrainian messages:');
....
```
in the main.dart to keep it simple, but if that is mandatory - just leave a comment, I'll push one more commit with this change.